### PR TITLE
technest-42: incluye funcionalidad básica del módulo de préstamos

### DIFF
--- a/src/main/java/com/example/vcloset/logic/entity/clothing/Clothing.java
+++ b/src/main/java/com/example/vcloset/logic/entity/clothing/Clothing.java
@@ -47,7 +47,7 @@ public class Clothing {
     @OneToMany(mappedBy = "clothing", orphanRemoval = true)
     private Set<Loan> loans = new LinkedHashSet<>();
 
-    @JsonIgnore
+
     @ManyToOne
     @JoinColumn(name = "user_id")
     private User user;

--- a/src/main/java/com/example/vcloset/logic/entity/clothing/ClothingRepository.java
+++ b/src/main/java/com/example/vcloset/logic/entity/clothing/ClothingRepository.java
@@ -20,4 +20,6 @@ public interface ClothingRepository extends JpaRepository<Clothing, Long> {
             @Param("typeParam") String type);
 
     Page<Clothing> findByIsClothingItemActiveTrueAndUserId(Long userId, Pageable pageable);
+
+    Page<Clothing> findByIsClothingItemActiveTrueAndIsPublicTrue(Pageable pageable);
 }

--- a/src/main/java/com/example/vcloset/rest/clothing/ClothingRestController.java
+++ b/src/main/java/com/example/vcloset/rest/clothing/ClothingRestController.java
@@ -210,4 +210,23 @@ public class ClothingRestController {
         }
     }
 
+    @GetMapping("/public")
+    @PreAuthorize("isAuthenticated()")
+    public ResponseEntity<?> getAllPublicClothing(
+            @RequestParam(defaultValue = "1") int page,
+            @RequestParam(defaultValue = "10") int size,
+            HttpServletRequest request) {
+
+        Pageable pageable = PageRequest.of(page - 1, size);
+        Page<Clothing> clothingPage = clothingRepository.findByIsClothingItemActiveTrueAndIsPublicTrue(pageable);
+        Meta meta = new Meta(request.getMethod(), request.getRequestURL().toString());
+        meta.setTotalPages(clothingPage.getTotalPages());
+        meta.setTotalElements(clothingPage.getTotalElements());
+        meta.setPageNumber(clothingPage.getNumber() + 1);
+        meta.setPageSize(clothingPage.getSize());
+        return new GlobalResponseHandler().handleResponse("Clothing Items retrieved successfully",
+                clothingPage.getContent(), HttpStatus.OK, meta);
+
+    }
+
 }


### PR DESCRIPTION
Módulo de Préstamos

- Incluye la estructura principal del módulo de préstamos, el usuario dueño de la prenda, y muestra todas las prendas que son públicas a los usuarios en el módulo de prendas.
- remueve JSONIgnore en la clase Clothing, para poder acceder a la información del usuario dueño de la prenda